### PR TITLE
do not take the question mark into query string

### DIFF
--- a/src/xavante/redirecthandler.lua
+++ b/src/xavante/redirecthandler.lua
@@ -38,7 +38,7 @@ local function redirect (req, res, dest, action, cap)
   end
 
   local path, query = path:match("^([^?]+)%??(.*)$")
-  if query and string.sub(query, 1, 1) ~= '&' then
+  if query:len() > 0 and string.sub(query, 1, 1) ~= '&' then
 	  query = '&'..query
   end
   req.parsed_url.path = path


### PR DESCRIPTION
I have a redirect match rule which will convert part of the url into one query string which named _path, below is the configuration code:

addrule{ -- URI remapping example
  match = "^/core/(.+)",
  with = redirecthandler,
  params = {"/index.lua?&_path=%1"}
}

The origin redirect handler will take the ? into the query string.
