### PR TITLE
Add IP to greeting message

### DIFF
--- a/src/xavante/httpd.lua
+++ b/src/xavante/httpd.lua
@@ -23,6 +23,7 @@ local _M = {}
 local _serversoftware = ""
 
 local _serverports = {}
+local _serverips = {}
 
 function _M.strsplit (str)
         local words = {}
@@ -376,16 +377,21 @@ function _M.register (host, port, serversoftware)
         local _server = assert(socket.bind(host, port))
         _serversoftware = serversoftware
         local _ip, _port = _server:getsockname()
+        if _ip == "0.0.0.0" then
+                _ip = "127.0.0.1"
+        end
+        table.insert(_serverips, _ip)
+        table.insert(_serverports, _port)
         _serverports[_port] = true
         copas.addserver(_server, _M.connection)
 end
 
 function _M.get_ports()
-  local ports = {}
-  for k, _ in pairs(_serverports) do
-    table.insert(ports, tostring(k))
-  end
-  return ports
+  return _serverports
+end
+
+function _M.get_ips()
+  return _serverips
 end
 
 return _M

--- a/src/xavante/xavante.lua
+++ b/src/xavante/xavante.lua
@@ -25,8 +25,19 @@ _M._COPYRIGHT   = "Copyright (C) 2004-2016 Kepler Project"
 _M._DESCRIPTION = "A Copas based Lua Web server with WSAPI support"
 _M._VERSION     = "Xavante 2.4.0"
 
-local _startmessage = function (ports)
-  print(string.format("Xavante started on port(s) %s", table.concat(ports, ", ")))
+local _startmessage = function(ports, ips)
+    local urls = {}
+
+    for i, port in ipairs(ports) do
+        table.insert(urls, string.format("http://%s:%s", ips[i], port))
+    end
+
+    if #urls == 1 then
+        print("Xavante started at " .. urls[1])
+    else
+        print("Xavante started at:")
+        print(table.concat(urls, "\n"))
+    end
 end
 
 local function _buildRules(rules)
@@ -90,7 +101,7 @@ end
 -- Starts the server
 -------------------------------------------------------------------------------
 function _M.start(isFinished, timeout)
-    _startmessage(httpd.get_ports())
+    _startmessage(httpd.get_ports(), httpd.get_ips())
     while true do
       if isFinished and isFinished() then break end
       copas.step(timeout)


### PR DESCRIPTION
`Xavante started on port(s) 8080` becomes
`Xavante started at http://127.0.0.1:8080`. Some terminals
allow the link in the new version to be easily opened.

Changed how xavante.httpd stores ports of active servers.
It also stores their ips now.
